### PR TITLE
XDG_RUNTIME_DIR fix

### DIFF
--- a/protonhax
+++ b/protonhax
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-phd=/run/user/$UID/protonhax
+phd=${XDG_RUNTIME_DIR:-/run/user/$UID}/protonhax
 
 usage() {
     echo "Usage:"


### PR DESCRIPTION
Adding the option to use XDG_RUNTIME_DIR instead of hardcode path.
